### PR TITLE
IoTCloudAPI holds a target instance

### DIFF
--- a/iotcloudsdk/src/androidTest/java/com/kii/iotcloud/IoTCloudAPI_CommandTest.java
+++ b/iotcloudsdk/src/androidTest/java/com/kii/iotcloud/IoTCloudAPI_CommandTest.java
@@ -64,7 +64,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         this.addMockResponseForPostNewCommand(201, commandID);
         this.addMockResponseForGetCommand(200, commandID, api.getOwner().getID(), thingID, actions, null, null, created, modified, schema);
 
-        Command command = api.postNewCommand(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions);
+        api.setTarget(target);
+        Command command = api.postNewCommand(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions);
         // verify the result
         Assert.assertEquals(commandID, command.getCommandID());
         Assert.assertEquals(DEMO_SCHEMA_NAME, command.getSchemaName());
@@ -130,7 +131,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(400);
 
         try {
-            api.postNewCommand(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions);
+            api.setTarget(target);
+            api.postNewCommand(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (BadRequestException e) {
         }
@@ -172,7 +174,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(403);
 
         try {
-            api.postNewCommand(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions);
+            api.setTarget(target);
+            api.postNewCommand(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ForbiddenException e) {
             Assert.assertEquals(403, e.getStatusCode());
@@ -215,7 +218,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(503);
 
         try {
-            api.postNewCommand(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions);
+            api.setTarget(target);
+            api.postNewCommand(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ServiceUnavailableException e) {
         }
@@ -242,14 +246,14 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         expectedRequestBody.add("actions", expectedActions);
         this.assertRequestBody(expectedRequestBody, request1);
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void postNewCommandWithNullTargetTest() throws Exception {
         List<Action> actions = new ArrayList<Action>();
         actions.add(new SetColor(128, 0, 255));
         actions.add(new SetColorTemperature(25));
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.postNewCommand(null, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions);
+        api.postNewCommand(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions);
     }
     @Test(expected = UnsupportedSchemaException.class)
     public void postNewCommandWithNullSchemaNameTest() throws Exception {
@@ -259,14 +263,16 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         actions.add(new SetColorTemperature(25));
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.postNewCommand(target, null, DEMO_SCHEMA_VERSION, actions);
+        api.setTarget(target);
+        api.postNewCommand(null, DEMO_SCHEMA_VERSION, actions);
     }
     @Test(expected = IllegalArgumentException.class)
     public void postNewCommandWithNullActionsTest() throws Exception {
         Target target = new Target(new TypedID(TypedID.Types.THING, "th.1234567890"), "thing-access-token-1234");
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.postNewCommand(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, null);
+        api.setTarget(target);
+        api.postNewCommand(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, null);
     }
     @Test(expected = IllegalArgumentException.class)
     public void postNewCommandWithEmptyActionsTest() throws Exception {
@@ -274,7 +280,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         List<Action> actions = new ArrayList<Action>();
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.postNewCommand(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions);
+        api.setTarget(target);
+        api.postNewCommand(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions);
     }
     @Test
     public void getCommandTest() throws Exception {
@@ -300,7 +307,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
         this.addMockResponseForGetCommand(200, commandID, api.getOwner().getID(), thingID, actions, actionResults, state, created, modified, schema);
 
-        Command command = api.getCommand(target, commandID);
+        api.setTarget(target);
+        Command command = api.getCommand(commandID);
 
         // verify the result
         Assert.assertEquals(commandID, command.getCommandID());
@@ -346,7 +354,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(403);
 
         try {
-            api.getCommand(target, commandID);
+            api.setTarget(target);
+            api.getCommand(commandID);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ForbiddenException e) {
         }
@@ -373,7 +382,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(404);
 
         try {
-            api.getCommand(target, commandID);
+            api.setTarget(target);
+            api.getCommand(commandID);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (NotFoundException e) {
         }
@@ -400,7 +410,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(503);
 
         try {
-            api.getCommand(target, commandID);
+            api.setTarget(target);
+            api.getCommand(commandID);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ServiceUnavailableException e) {
         }
@@ -447,7 +458,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         this.addMockResponseForGetCommand(200, commandID, api.getOwner().getID(), thingID, actions, actionResults, state, created, modified, schema);
 
         try {
-            api.getCommand(target, commandID);
+            api.setTarget(target);
+            api.getCommand(commandID);
             Assert.fail("UnsupportedSchemaException should be thrown");
         } catch (UnsupportedSchemaException e) {
         }
@@ -494,7 +506,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         this.addMockResponseForGetCommand(200, commandID, api.getOwner().getID(), thingID, actions, actionResults, state, created, modified, schema);
 
         try {
-            api.getCommand(target, commandID);
+            api.setTarget(target);
+            api.getCommand(commandID);
             Assert.fail("UnsupportedSchemaException should be thrown");
         } catch (UnsupportedSchemaException e) {
         }
@@ -537,7 +550,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
 
         GsonRepository.clearCache();
         try {
-            api.getCommand(target, commandID);
+            api.setTarget(target);
+            api.getCommand(commandID);
             Assert.fail("UnsupportedActionException should be thrown");
         } catch (UnsupportedActionException e) {
         }
@@ -552,12 +566,12 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
         this.assertRequestHeader(expectedRequestHeaders, request);
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void getCommandWithNullTargetTest() throws Exception {
         String commandID = "command-1234";
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.getCommand(null, commandID);
+        api.getCommand(commandID);
     }
     @Test(expected = IllegalArgumentException.class)
     public void getCommandWithNullCommandIDTest() throws Exception {
@@ -566,7 +580,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         Target target = new Target(thingID, accessToken);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.getCommand(target, null);
+        api.setTarget(target);
+        api.getCommand(null);
     }
     @Test(expected = IllegalArgumentException.class)
     public void getCommandWithEmptyCommandIDTest() throws Exception {
@@ -575,7 +590,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         Target target = new Target(thingID, accessToken);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.getCommand(target, "");
+        api.setTarget(target);
+        api.getCommand("");
     }
     @Test
     public void listCommandsTest() throws Exception {
@@ -586,6 +602,7 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         String paginationKey = "pagination-12345-key";
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.setTarget(target);
 
         List<Action> command1Actions = new ArrayList<Action>();
         command1Actions.add(new TurnPower(true));
@@ -618,14 +635,14 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         this.addMockResponseForListCommands(200, new Command[]{command3}, null, schema);
 
         // verify the result
-        Pair<List<Command>, String> result1 = api.listCommands(target, 10, null);
+        Pair<List<Command>, String> result1 = api.listCommands(10, null);
         Assert.assertEquals(paginationKey, result1.second);
         List<Command> commands1 = result1.first;
         Assert.assertEquals(2, commands1.size());
         this.assertCommand(schema, command1, commands1.get(0));
         this.assertCommand(schema, command2, commands1.get(1));
 
-        Pair<List<Command>, String> result2= api.listCommands(target, 10, result1.second);
+        Pair<List<Command>, String> result2= api.listCommands(10, result1.second);
         Assert.assertNull(result2.second);
         List<Command> commands2 = result2.first;
         Assert.assertEquals(1, commands2.size());
@@ -670,7 +687,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         this.addMockResponseForListCommands(200, new Command[]{command}, paginationKey, schema);
 
         // verify the result
-        Pair<List<Command>, String> result = api.listCommands(target, 0, null);
+        api.setTarget(target);
+        Pair<List<Command>, String> result = api.listCommands(0, null);
         Assert.assertEquals(paginationKey, result.second);
         List<Command> commands = result.first;
         Assert.assertEquals(1, commands.size());
@@ -700,7 +718,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(400);
 
         try {
-            api.listCommands(target, 10, null);
+            api.setTarget(target);
+            api.listCommands(10, null);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (BadRequestException e) {
         }
@@ -728,7 +747,8 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(404);
 
         try {
-            api.listCommands(target, 10, null);
+            api.setTarget(target);
+            api.listCommands(10, null);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (NotFoundException e) {
         }
@@ -743,10 +763,10 @@ public class IoTCloudAPI_CommandTest extends IoTCloudAPITestBase {
         expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
         this.assertRequestHeader(expectedRequestHeaders, request);
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void listCommandsWithNullTargetTest() throws Exception {
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.listCommands(null, 10, null);
+        api.listCommands(10, null);
     }
 
 }

--- a/iotcloudsdk/src/androidTest/java/com/kii/iotcloud/IoTCloudAPI_TargetStateTest.java
+++ b/iotcloudsdk/src/androidTest/java/com/kii/iotcloud/IoTCloudAPI_TargetStateTest.java
@@ -35,7 +35,8 @@ public class IoTCloudAPI_TargetStateTest extends IoTCloudAPITestBase {
         this.addMockResponse(200, new JsonParser().parse(responseBody));
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        LightState lightState = api.getTargetState(target, LightState.class);
+        api.setTarget(target);
+        LightState lightState = api.getTargetState(LightState.class);
         // verify the result
         Assert.assertEquals(true, lightState.power);
         Assert.assertEquals(90, lightState.brightness);
@@ -52,17 +53,18 @@ public class IoTCloudAPI_TargetStateTest extends IoTCloudAPITestBase {
         expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
         this.assertRequestHeader(expectedRequestHeaders, request);
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void getTargetStateWithNullTargetTest() throws Exception {
+        IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.getTargetState(LightState.class);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void getTargetStateWithNullClassTest() throws Exception {
         TypedID thingID = new TypedID(TypedID.Types.THING, "th.1234567890");
         String accessToken = "thing-access-token-1234";
         Target target = new Target(thingID, accessToken);
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.getTargetState(target, null);
-    }
-    @Test(expected = IllegalArgumentException.class)
-    public void getTargetStateWithNullClassTest() throws Exception {
-        IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.getTargetState(null, LightState.class);
+        api.setTarget(target);
+        api.getTargetState(null);
     }
 }

--- a/iotcloudsdk/src/androidTest/java/com/kii/iotcloud/IoTCloudAPI_TriggerTest.java
+++ b/iotcloudsdk/src/androidTest/java/com/kii/iotcloud/IoTCloudAPI_TriggerTest.java
@@ -67,7 +67,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addMockResponseForPostNewTrigger(201, triggerID);
         this.addMockResponseForGetTrigger(200, triggerID, expectedCommand, predicate, false, null, schema);
 
-        Trigger trigger = api.postNewTrigger(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
+        api.setTarget(target);
+        Trigger trigger = api.postNewTrigger(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -122,7 +123,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(403);
 
         try {
-            api.postNewTrigger(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
+            api.setTarget(target);
+            api.postNewTrigger(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ForbiddenException e) {
         }
@@ -163,7 +165,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(404);
 
         try {
-            api.postNewTrigger(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
+            api.setTarget(target);
+            api.postNewTrigger(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (NotFoundException e) {
         }
@@ -204,7 +207,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(503);
 
         try {
-            api.postNewTrigger(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
+            api.setTarget(target);
+            api.postNewTrigger(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ServiceUnavailableException e) {
         }
@@ -225,7 +229,7 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         expectedRequestBody.add("predicate", GsonRepository.gson(schema).toJsonTree(predicate));
         this.assertRequestBody(expectedRequestBody, request);
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void postNewTriggerWithNullTargetTest() throws Exception {
         List<Action> actions = new ArrayList<Action>();
         SetColor setColor = new SetColor(128, 0, 255);
@@ -235,7 +239,7 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         StatePredicate predicate = new StatePredicate(new Condition(new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.postNewTrigger(null, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
+        api.postNewTrigger(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
     }
     @Test(expected = IllegalArgumentException.class)
     public void postNewTriggerWithNullSchemaNameTest() throws Exception {
@@ -251,7 +255,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         StatePredicate predicate = new StatePredicate(new Condition(new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.postNewTrigger(target, null, DEMO_SCHEMA_VERSION, actions, predicate);
+        api.setTarget(target);
+        api.postNewTrigger(null, DEMO_SCHEMA_VERSION, actions, predicate);
     }
     @Test(expected = IllegalArgumentException.class)
     public void postNewTriggerWithEmptySchemaNameTest() throws Exception {
@@ -267,7 +272,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         StatePredicate predicate = new StatePredicate(new Condition(new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.postNewTrigger(target, "", DEMO_SCHEMA_VERSION, actions, predicate);
+        api.setTarget(target);
+        api.postNewTrigger("", DEMO_SCHEMA_VERSION, actions, predicate);
     }
     @Test(expected = IllegalArgumentException.class)
     public void postNewTriggerWithNullActionsTest() throws Exception {
@@ -278,7 +284,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         StatePredicate predicate = new StatePredicate(new Condition(new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.postNewTrigger(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, null, predicate);
+        api.setTarget(target);
+        api.postNewTrigger(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, null, predicate);
     }
     @Test(expected = IllegalArgumentException.class)
     public void postNewTriggerWithEmptyActionsTest() throws Exception {
@@ -290,7 +297,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         StatePredicate predicate = new StatePredicate(new Condition(new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.postNewTrigger(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
+        api.setTarget(target);
+        api.postNewTrigger(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
     }
     @Test(expected = IllegalArgumentException.class)
     public void postNewTriggerWithNullPredicateTest() throws Exception {
@@ -305,7 +313,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         actions.add(setColorTemperature);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.postNewTrigger(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, null);
+        api.setTarget(target);
+        api.postNewTrigger(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, null);
     }
     @Test
     public void getTriggerTest() throws Exception {
@@ -327,7 +336,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         Command expectedCommand = new Command(schema.getSchemaName(), schema.getSchemaVersion(), target.getID(), api.getOwner().getID(), actions);
         this.addMockResponseForGetTrigger(200, triggerID, expectedCommand, predicate, true, "COMMAND_EXECUTION_REJECTED", schema);
 
-        Trigger trigger = api.getTrigger(target, triggerID);
+        api.setTarget(target);
+        Trigger trigger = api.getTrigger(triggerID);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(true, trigger.disabled());
@@ -357,7 +367,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(403);
 
         try {
-            api.getTrigger(target, triggerID);
+            api.setTarget(target);
+            api.getTrigger(triggerID);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ForbiddenException e) {
         }
@@ -384,7 +395,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(404);
 
         try {
-            api.getTrigger(target, triggerID);
+            api.setTarget(target);
+            api.getTrigger(triggerID);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (NotFoundException e) {
         }
@@ -411,7 +423,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(503);
 
         try {
-            api.getTrigger(target, triggerID);
+            api.setTarget(target);
+            api.getTrigger(triggerID);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ServiceUnavailableException e) {
         }
@@ -453,7 +466,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addMockResponseForGetTrigger(200, triggerID, expectedCommand, predicate, true, "COMMAND_EXECUTION_REJECTED", schema);
 
         try {
-            api.getTrigger(target, triggerID);
+            api.setTarget(target);
+            api.getTrigger(triggerID);
             Assert.fail("UnsupportedSchemaException should be thrown");
         } catch (UnsupportedSchemaException e) {
         }
@@ -495,7 +509,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addMockResponseForGetTrigger(200, triggerID, expectedCommand, predicate, true, "COMMAND_EXECUTION_REJECTED", schema);
 
         try {
-            api.getTrigger(target, triggerID);
+            api.setTarget(target);
+            api.getTrigger(triggerID);
             Assert.fail("UnsupportedSchemaException should be thrown");
         } catch (UnsupportedSchemaException e) {
         }
@@ -537,7 +552,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
 
         GsonRepository.clearCache();
         try {
-            api.getTrigger(target, triggerID);
+            api.setTarget(target);
+            api.getTrigger(triggerID);
             Assert.fail("UnsupportedActionException should be thrown");
         } catch (UnsupportedActionException e) {
         }
@@ -552,12 +568,12 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
         this.assertRequestHeader(expectedRequestHeaders, request);
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void getTriggerWithNullTargetTest() throws Exception {
         String triggerID = "trigger-1234";
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.getTrigger(null, triggerID);
+        api.getTrigger(triggerID);
     }
     @Test(expected = IllegalArgumentException.class)
     public void getTriggerWithNullTriggerIDTest() throws Exception {
@@ -567,7 +583,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         Target target = new Target(thingID, accessToken);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.getTrigger(target, null);
+        api.setTarget(target);
+        api.getTrigger(null);
     }
     @Test(expected = IllegalArgumentException.class)
     public void getTriggerWithEmptyTriggerIDTest() throws Exception {
@@ -577,7 +594,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         Target target = new Target(thingID, accessToken);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.getTrigger(target, "");
+        api.setTarget(target);
+        api.getTrigger("");
     }
     @Test
     public void enableTriggerTest() throws Exception {
@@ -600,7 +618,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(204);
         this.addMockResponseForGetTrigger(200, triggerID, expectedCommand, predicate, false, null, schema);
 
-        Trigger trigger = api.enableTrigger(target, triggerID, true);
+        api.setTarget(target);
+        Trigger trigger = api.enableTrigger(triggerID, true);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -644,7 +663,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(204);
         this.addMockResponseForGetTrigger(200, triggerID, expectedCommand, predicate, true, null, schema);
 
-        Trigger trigger = api.enableTrigger(target, triggerID, false);
+        api.setTarget(target);
+        Trigger trigger = api.enableTrigger(triggerID, false);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(true, trigger.disabled());
@@ -676,7 +696,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
         this.addEmptyMockResponse(403);
         try {
-            api.enableTrigger(target, triggerID, false);
+            api.setTarget(target);
+            api.enableTrigger(triggerID, false);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ForbiddenException e) {
         }
@@ -694,7 +715,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
         this.addEmptyMockResponse(404);
         try {
-            api.enableTrigger(target, triggerID, false);
+            api.setTarget(target);
+            api.enableTrigger(triggerID, false);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (NotFoundException e) {
         }
@@ -712,7 +734,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
         this.addEmptyMockResponse(503);
         try {
-            api.enableTrigger(target, triggerID, false);
+            api.setTarget(target);
+            api.enableTrigger(triggerID, false);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ServiceUnavailableException e) {
         }
@@ -721,11 +744,11 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() + "/triggers/" + triggerID + "/disable", request.getPath());
         Assert.assertEquals("PUT", request.getMethod());
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void enableTriggerWithNullTargetTest() throws Exception {
         String triggerID = "trigger-1234";
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.enableTrigger(null, triggerID, false);
+        api.enableTrigger(triggerID, false);
     }
     @Test(expected = IllegalArgumentException.class)
     public void enableTriggerWithNullTriggerIDTest() throws Exception {
@@ -733,7 +756,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         String accessToken = "thing-access-token-1234";
         Target target = new Target(thingID, accessToken);
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.enableTrigger(target, null, false);
+        api.setTarget(target);
+        api.enableTrigger(null, false);
     }
     @Test(expected = IllegalArgumentException.class)
     public void enableTriggerWithEmptyTriggerIDTest() throws Exception {
@@ -741,7 +765,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         String accessToken = "thing-access-token-1234";
         Target target = new Target(thingID, accessToken);
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.enableTrigger(target, "", false);
+        api.setTarget(target);
+        api.enableTrigger("", false);
     }
     @Test
     public void listTriggersTest() throws Exception {
@@ -752,6 +777,7 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         String paginationKey = "pagination-12345-key";
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.setTarget(target);
 
         List<Action> command1Actions = new ArrayList<Action>();
         command1Actions.add(new TurnPower(true));
@@ -779,14 +805,14 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addMockResponseForListTriggers(200, new Trigger[]{trigger3}, null, schema);
 
         // verify the result
-        Pair<List<Trigger>, String> result1 = api.listTriggers(target, 10, null);
+        Pair<List<Trigger>, String> result1 = api.listTriggers(10, null);
         Assert.assertEquals(paginationKey, result1.second);
         List<Trigger> triggers1 = result1.first;
         Assert.assertEquals(2, triggers1.size());
         this.assertTrigger(schema, trigger1, triggers1.get(0));
         this.assertTrigger(schema, trigger2, triggers1.get(1));
 
-        Pair<List<Trigger>, String> result2 = api.listTriggers(target, 10, result1.second);
+        Pair<List<Trigger>, String> result2 = api.listTriggers(10, result1.second);
         Assert.assertNull(result2.second);
         List<Trigger> triggers2 = result2.first;
         Assert.assertEquals(1, triggers2.size());
@@ -818,6 +844,7 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         String paginationKey = "pagination-12345-key";
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.setTarget(target);
 
         List<Action> command1Actions = new ArrayList<Action>();
         command1Actions.add(new TurnPower(true));
@@ -845,14 +872,14 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addMockResponseForListTriggers(200, new Trigger[]{trigger3}, null, schema);
 
         // verify the result
-        Pair<List<Trigger>, String> result1 = api.listTriggers(target, 0, null);
+        Pair<List<Trigger>, String> result1 = api.listTriggers(0, null);
         Assert.assertEquals(paginationKey, result1.second);
         List<Trigger> triggers1 = result1.first;
         Assert.assertEquals(2, triggers1.size());
         this.assertTrigger(schema, trigger1, triggers1.get(0));
         this.assertTrigger(schema, trigger2, triggers1.get(1));
 
-        Pair<List<Trigger>, String> result2 = api.listTriggers(target, 0, result1.second);
+        Pair<List<Trigger>, String> result2 = api.listTriggers(0, result1.second);
         Assert.assertNull(result2.second);
         List<Trigger> triggers2 = result2.first;
         Assert.assertEquals(1, triggers2.size());
@@ -885,7 +912,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
         this.addEmptyMockResponse(400);
         try {
-            api.listTriggers(target, 10, null);
+            api.setTarget(target);
+            api.listTriggers(10, null);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (BadRequestException e) {
         }
@@ -910,7 +938,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
         this.addEmptyMockResponse(403);
         try {
-            api.listTriggers(target, 10, null);
+            api.setTarget(target);
+            api.listTriggers(10, null);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ForbiddenException e) {
         }
@@ -935,7 +964,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
         this.addEmptyMockResponse(404);
         try {
-            api.listTriggers(target, 10, null);
+            api.setTarget(target);
+            api.listTriggers(10, null);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (NotFoundException e) {
         }
@@ -960,7 +990,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
         this.addEmptyMockResponse(503);
         try {
-            api.listTriggers(target, 10, null);
+            api.setTarget(target);
+            api.listTriggers(10, null);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ServiceUnavailableException e) {
         }
@@ -975,10 +1006,10 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
         this.assertRequestHeader(expectedRequestHeaders, request1);
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void listTriggersWithNullTargetTest() throws Exception {
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.listTriggers(null, 10, null);
+        api.listTriggers(10, null);
     }
     @Test
     public void deleteTriggerTest() throws Exception {
@@ -1001,7 +1032,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addMockResponseForGetTrigger(200, triggerID, expectedCommand, predicate, false, null, schema);
         this.addEmptyMockResponse(204);
 
-        Trigger trigger = api.deleteTrigger(target, triggerID);
+        api.setTarget(target);
+        Trigger trigger = api.deleteTrigger(triggerID);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -1037,7 +1069,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(403);
 
         try {
-            api.deleteTrigger(target, triggerID);
+            api.setTarget(target);
+            api.deleteTrigger(triggerID);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ForbiddenException e) {
         }
@@ -1064,7 +1097,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(404);
 
         try {
-            api.deleteTrigger(target, triggerID);
+            api.setTarget(target);
+            api.deleteTrigger(triggerID);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (NotFoundException e) {
         }
@@ -1091,7 +1125,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(503);
 
         try {
-            api.deleteTrigger(target, triggerID);
+            api.setTarget(target);
+            api.deleteTrigger(triggerID);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ServiceUnavailableException e) {
         }
@@ -1106,12 +1141,12 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
         this.assertRequestHeader(expectedRequestHeaders, request1);
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void deleteTriggerWithNullTargetTest() throws Exception {
         String triggerID = "trigger-1234";
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.deleteTrigger(null, triggerID);
+        api.deleteTrigger(triggerID);
     }
     @Test(expected = IllegalArgumentException.class)
     public void deleteTriggerWithNullTriggerIDTest() throws Exception {
@@ -1120,7 +1155,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         Target target = new Target(thingID, accessToken);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.deleteTrigger(target, null);
+        api.setTarget(target);
+        api.deleteTrigger(null);
     }
     @Test(expected = IllegalArgumentException.class)
     public void deleteTriggerWithEmptyTriggerIDTest() throws Exception {
@@ -1129,7 +1165,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         Target target = new Target(thingID, accessToken);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.deleteTrigger(target, "");
+        api.setTarget(target);
+        api.deleteTrigger("");
     }
     @Test
     public void patchTriggerTest() throws Exception {
@@ -1152,7 +1189,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(204);
         this.addMockResponseForGetTrigger(200, triggerID, expectedCommand, predicate, false, null, schema);
 
-        Trigger trigger = api.patchTrigger(target, triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
+        api.setTarget(target);
+        Trigger trigger = api.patchTrigger(triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -1208,7 +1246,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(403);
 
         try {
-            api.patchTrigger(target, triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
+            api.setTarget(target);
+            api.patchTrigger(triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ForbiddenException e) {
         }
@@ -1250,7 +1289,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(404);
 
         try {
-            api.patchTrigger(target, triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
+            api.setTarget(target);
+            api.patchTrigger(triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (NotFoundException e) {
         }
@@ -1292,7 +1332,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         this.addEmptyMockResponse(503);
 
         try {
-            api.patchTrigger(target, triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
+            api.setTarget(target);
+            api.patchTrigger(triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
             Assert.fail("IoTCloudRestException should be thrown");
         } catch (ServiceUnavailableException e) {
         }
@@ -1313,7 +1354,7 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         expectedRequestBody.add("predicate", GsonRepository.gson(schema).toJsonTree(predicate));
         this.assertRequestBody(expectedRequestBody, request);
     }
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = IllegalStateException.class)
     public void patchTriggerWithNullTargetTest() throws Exception {
         Schema schema = this.createDefaultSchema();
         String triggerID = "trigger-1234";
@@ -1326,7 +1367,7 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         StatePredicate predicate = new StatePredicate(new Condition(new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.patchTrigger(null, triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
+        api.patchTrigger(triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
     }
     @Test(expected = IllegalArgumentException.class)
     public void patchTriggerWithNullTriggerIDTest() throws Exception {
@@ -1343,7 +1384,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         StatePredicate predicate = new StatePredicate(new Condition(new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.patchTrigger(target, null, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
+        api.setTarget(target);
+        api.patchTrigger(null, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
     }
     @Test(expected = IllegalArgumentException.class)
     public void patchTriggerWithEmptyTriggerIDTest() throws Exception {
@@ -1360,7 +1402,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         StatePredicate predicate = new StatePredicate(new Condition(new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.patchTrigger(target, null, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
+        api.setTarget(target);
+        api.patchTrigger(null, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
     }
     @Test(expected = IllegalArgumentException.class)
     public void patchTriggerWithNullSchemaNameTest() throws Exception {
@@ -1378,7 +1421,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         StatePredicate predicate = new StatePredicate(new Condition(new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.patchTrigger(target, triggerID, null, DEMO_SCHEMA_VERSION, actions, predicate);
+        api.setTarget(target);
+        api.patchTrigger(triggerID, null, DEMO_SCHEMA_VERSION, actions, predicate);
     }
     @Test(expected = IllegalArgumentException.class)
     public void patchTriggerWithEmptySchemaNameTest() throws Exception {
@@ -1396,7 +1440,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         StatePredicate predicate = new StatePredicate(new Condition(new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.patchTrigger(target, triggerID, "", DEMO_SCHEMA_VERSION, actions, predicate);
+        api.setTarget(target);
+        api.patchTrigger(triggerID, "", DEMO_SCHEMA_VERSION, actions, predicate);
     }
     @Test(expected = IllegalArgumentException.class)
     public void patchTriggerWithNullActionsTest() throws Exception {
@@ -1409,7 +1454,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         StatePredicate predicate = new StatePredicate(new Condition(new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.patchTrigger(target, triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, null, predicate);
+        api.setTarget(target);
+        api.patchTrigger(triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, null, predicate);
     }
     @Test(expected = IllegalArgumentException.class)
     public void patchTriggerWithEmptyActionsTest() throws Exception {
@@ -1423,7 +1469,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         StatePredicate predicate = new StatePredicate(new Condition(new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.patchTrigger(target, triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
+        api.setTarget(target);
+        api.patchTrigger(triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate);
     }
     @Test(expected = IllegalArgumentException.class)
     public void patchTriggerWithNullPredicateTest() throws Exception {
@@ -1439,7 +1486,8 @@ public class IoTCloudAPI_TriggerTest extends IoTCloudAPITestBase {
         actions.add(setColorTemperature);
 
         IoTCloudAPI api = this.craeteIoTCloudAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.patchTrigger(target, triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, null);
+        api.setTarget(target);
+        api.patchTrigger(triggerID, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, null);
     }
 }
 

--- a/iotcloudsdk/src/main/java/com/kii/iotcloud/IoTCloudAPI.java
+++ b/iotcloudsdk/src/main/java/com/kii/iotcloud/IoTCloudAPI.java
@@ -728,7 +728,7 @@ public class IoTCloudAPI implements Parcelable, Serializable {
     public Target getTarget() {
         return this.target;
     }
-    public void setTarget() {
+    public void setTarget(Target target) {
         this.target = target;
     }
 

--- a/iotcloudsdk/src/main/java/com/kii/iotcloud/IoTCloudAPI.java
+++ b/iotcloudsdk/src/main/java/com/kii/iotcloud/IoTCloudAPI.java
@@ -50,9 +50,9 @@ public class IoTCloudAPI implements Parcelable, Serializable {
     private final String appKey;
     private final String baseUrl;
     private final Owner owner;
+    private Target target;
     private final Map<Pair<String, Integer>, Schema> schemas = new HashMap<Pair<String, Integer>, Schema>();
     private final IoTRestClient restClient;
-    private boolean onBoarded = false;
     private String installationID;
 
     IoTCloudAPI(
@@ -165,8 +165,8 @@ public class IoTCloudAPI implements Parcelable, Serializable {
         JSONObject responseBody = this.restClient.sendRequest(request);
         String thingID = responseBody.optString("thingID", null);
         String accessToken = responseBody.optString("accessToken", null);
-        this.onBoarded = true;
-        return new Target(new TypedID(TypedID.Types.THING, thingID), accessToken);
+        this.target = new Target(new TypedID(TypedID.Types.THING, thingID), accessToken);
+        return this.target;
     }
 
     /**
@@ -175,7 +175,7 @@ public class IoTCloudAPI implements Parcelable, Serializable {
      */
     public boolean onBoarded()
     {
-        return this.onBoarded;
+        return this.target != null;
     }
 
     /**
@@ -257,7 +257,6 @@ public class IoTCloudAPI implements Parcelable, Serializable {
      * Post new command to IoT Cloud.
      * Command will be delivered to specified target and result will be notified
      * through push notification.
-     * @param target Target of the command to be delivered.
      * @param schemaName name of the schema.
      * @param schemaVersion version of schema.
      * @param actions Actions to be executed.
@@ -271,12 +270,11 @@ public class IoTCloudAPI implements Parcelable, Serializable {
     @NonNull
     @WorkerThread
     public Command postNewCommand(
-            @NonNull Target target,
             @NonNull String schemaName,
             int schemaVersion,
             @NonNull List<Action> actions) throws IoTCloudException {
-        if (target == null) {
-            throw new IllegalArgumentException("target is null");
+        if (this.target == null) {
+            throw new IllegalStateException("Can not perform this action before onboarding");
         }
         Schema schema = this.getSchema(schemaName, schemaVersion);
         if (schema == null) {
@@ -286,7 +284,7 @@ public class IoTCloudAPI implements Parcelable, Serializable {
             throw new IllegalArgumentException("actions is null or empty");
         }
 
-        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/commands", this.appID, target.getID().toString());
+        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/commands", this.appID, this.target.getID().toString());
         String url = Path.combine(this.baseUrl, path);
         Map<String, String> headers = this.newHeader();
         Command command = new Command(schemaName, schemaVersion, this.owner.getID(), actions);
@@ -295,12 +293,11 @@ public class IoTCloudAPI implements Parcelable, Serializable {
         JSONObject responseBody = this.restClient.sendRequest(request);
 
         String commandID = responseBody.optString("commandID", null);
-        return this.getCommand(target, commandID);
+        return this.getCommand(commandID);
     }
 
     /**
      * Get specified command.
-     * @param target Target of the command.
      * @param commandID ID of the command to obtain. ID is present in the
      *                  instance returned by {@link #postNewCommand}
      *                  and can be obtained by {@link Command#getCommandID}
@@ -314,17 +311,16 @@ public class IoTCloudAPI implements Parcelable, Serializable {
     @NonNull
     @WorkerThread
     public Command getCommand(
-            @NonNull Target target,
             @NonNull String commandID)
             throws IoTCloudException {
 
-        if (target == null) {
-            throw new IllegalArgumentException("target is null");
+        if (this.target == null) {
+            throw new IllegalStateException("Can not perform this action before onboarding");
         }
         if (TextUtils.isEmpty(commandID)) {
             throw new IllegalArgumentException("commandID is null or empty");
         }
-        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/commands/{2}", this.appID, target.getID().toString(), commandID);
+        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/commands/{2}", this.appID, this.target.getID().toString(), commandID);
         String url = Path.combine(this.baseUrl, path);
         Map<String, String> headers = this.newHeader();
         IoTRestRequest request = new IoTRestRequest(url, IoTRestRequest.Method.GET, headers);
@@ -340,7 +336,6 @@ public class IoTCloudAPI implements Parcelable, Serializable {
     }
     /**
      * List Commands in the specified Target.
-     * @param target Target to which the Commands belongs.
      * @param bestEffortLimit Maximum number of the Commands in the response.
      *                        if the value is <= 0, default limit internally
      *                        defined is applied.
@@ -360,15 +355,14 @@ public class IoTCloudAPI implements Parcelable, Serializable {
      * @throws UnsupportedActionException Thrown when the returned response has a action that cannot handle this instance.
      */
     public Pair<List<Command>, String> listCommands (
-            @NonNull Target target,
             int bestEffortLimit,
             @Nullable String paginationKey)
             throws IoTCloudException {
 
-        if (target == null) {
-            throw new IllegalArgumentException("target is null");
+        if (this.target == null) {
+            throw new IllegalStateException("Can not perform this action before onboarding");
         }
-        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/commands", this.appID, target.getID().toString());
+        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/commands", this.appID, this.target.getID().toString());
         String url = Path.combine(this.baseUrl, path);
         Map<String, String> headers = this.newHeader();
         IoTRestRequest request = new IoTRestRequest(url, IoTRestRequest.Method.GET, headers);
@@ -400,9 +394,6 @@ public class IoTCloudAPI implements Parcelable, Serializable {
 
     /**
      * Post new Trigger to IoT Cloud.
-     * @param target Target of which the trigger stored. It the trigger is based
-     *               on state of target, Trigger is evaluated when the state of
-     *               the target has been updated.
      * @param schemaName name of the schema.
      * @param schemaVersion version of schema.
      * @param actions Specify actions included in the Command is fired by the
@@ -415,15 +406,14 @@ public class IoTCloudAPI implements Parcelable, Serializable {
     @NonNull
     @WorkerThread
     public Trigger postNewTrigger(
-            @NonNull Target target,
             @NonNull String schemaName,
             int schemaVersion,
             @NonNull List<Action> actions,
             @NonNull Predicate predicate)
             throws IoTCloudException {
 
-        if (target == null) {
-            throw new IllegalArgumentException("target is null");
+        if (this.target == null) {
+            throw new IllegalStateException("Can not perform this action before onboarding");
         }
         if (TextUtils.isEmpty(schemaName)) {
             throw new IllegalArgumentException("schemaName is null or empty");
@@ -435,12 +425,12 @@ public class IoTCloudAPI implements Parcelable, Serializable {
             throw new IllegalArgumentException("predicate is null");
         }
 
-        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/triggers", this.appID, target.getID().toString());
+        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/triggers", this.appID, this.target.getID().toString());
         String url = Path.combine(this.baseUrl, path);
         Map<String, String> headers = this.newHeader();
         JSONObject requestBody = new JSONObject();
         Schema schema = this.getSchema(schemaName, schemaVersion);
-        Command command = new Command(schemaName, schemaVersion, target.getID(), this.owner.getID(), actions);
+        Command command = new Command(schemaName, schemaVersion, this.target.getID(), this.owner.getID(), actions);
         try {
             requestBody.put("predicate", JsonUtils.newJson(GsonRepository.gson(schema).toJson(predicate)));
             requestBody.put("command", JsonUtils.newJson(GsonRepository.gson(schema).toJson(command)));
@@ -450,12 +440,11 @@ public class IoTCloudAPI implements Parcelable, Serializable {
         IoTRestRequest request = new IoTRestRequest(url, IoTRestRequest.Method.POST, headers, MEDIA_TYPE_JSON, requestBody);
         JSONObject responseBody = this.restClient.sendRequest(request);
         String triggerID = responseBody.optString("triggerID", null);
-        return this.getTrigger(target, triggerID);
+        return this.getTrigger(triggerID);
     }
 
     /**
      * Get specified Trigger.
-     * @param target Target of which the trigger stored.
      * @param triggerID ID of the Trigger to get.
      * @return Trigger instance.
      * @throws IoTCloudException Thrown when failed to connect IoT Cloud Server.
@@ -466,18 +455,17 @@ public class IoTCloudAPI implements Parcelable, Serializable {
     @NonNull
     @WorkerThread
     public Trigger getTrigger(
-            @NonNull Target target,
             @NonNull String triggerID)
             throws IoTCloudException {
 
-        if (target == null) {
-            throw new IllegalArgumentException("target is null");
+        if (this.target == null) {
+            throw new IllegalStateException("Can not perform this action before onboarding");
         }
         if (TextUtils.isEmpty(triggerID)) {
             throw new IllegalArgumentException("triggerID is null or empty");
         }
 
-        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/triggers/{2}", this.appID, target.getID().toString(), triggerID);
+        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/triggers/{2}", this.appID, this.target.getID().toString(), triggerID);
         String url = Path.combine(this.baseUrl, path);
         Map<String, String> headers = this.newHeader();
         IoTRestRequest request = new IoTRestRequest(url, IoTRestRequest.Method.GET, headers);
@@ -496,7 +484,6 @@ public class IoTCloudAPI implements Parcelable, Serializable {
     /**
      * Apply Patch to registered Trigger
      * Modify registered Trigger with specified patch.
-     * @param target Target of which the Trigger stored
      * @param triggerID ID ot the Trigger to apply patch
      * @param schemaName name of the schema.
      * @param schemaVersion version of schema.
@@ -512,7 +499,6 @@ public class IoTCloudAPI implements Parcelable, Serializable {
     @NonNull
     @WorkerThread
     public Trigger patchTrigger(
-            @NonNull Target target,
             @NonNull String triggerID,
             @NonNull String schemaName,
             int schemaVersion,
@@ -520,8 +506,8 @@ public class IoTCloudAPI implements Parcelable, Serializable {
             @Nullable Predicate predicate) throws
             IoTCloudException {
 
-        if (target == null) {
-            throw new IllegalArgumentException("target is null");
+        if (this.target == null) {
+            throw new IllegalStateException("Can not perform this action before onboarding");
         }
         if (TextUtils.isEmpty(triggerID)) {
             throw new IllegalArgumentException("triggerID is null or empty");
@@ -536,12 +522,12 @@ public class IoTCloudAPI implements Parcelable, Serializable {
             throw new IllegalArgumentException("predicate is null");
         }
 
-        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/triggers/{2}", this.appID, target.getID().toString(), triggerID);
+        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/triggers/{2}", this.appID, this.target.getID().toString(), triggerID);
         String url = Path.combine(this.baseUrl, path);
         Map<String, String> headers = this.newHeader();
         JSONObject requestBody = new JSONObject();
         Schema schema = this.getSchema(schemaName, schemaVersion);
-        Command command = new Command(schemaName, schemaVersion, target.getID(), this.owner.getID(), actions);
+        Command command = new Command(schemaName, schemaVersion, this.target.getID(), this.owner.getID(), actions);
         try {
             requestBody.put("predicate", JsonUtils.newJson(GsonRepository.gson(schema).toJson(predicate)));
             requestBody.put("command", JsonUtils.newJson(GsonRepository.gson(schema).toJson(command)));
@@ -550,14 +536,13 @@ public class IoTCloudAPI implements Parcelable, Serializable {
         }
         IoTRestRequest request = new IoTRestRequest(url, IoTRestRequest.Method.PATCH, headers, MEDIA_TYPE_JSON, requestBody);
         this.restClient.sendRequest(request);
-        return this.getTrigger(target, triggerID);
+        return this.getTrigger(triggerID);
     }
 
     /**
      * Enable/Disable registered Trigger
      * If its already enabled(/disabled),
      * this method won't throw Exception and behave as succeeded.
-     * @param target Target of which the Trigger stored.
      * @param triggerID ID of the Trigger to be enabled(/disabled).
      * @param enable specify whether enable of disable the Trigger.
      * @return Updated Trigger Instance.
@@ -567,28 +552,26 @@ public class IoTCloudAPI implements Parcelable, Serializable {
     @NonNull
     @WorkerThread
     public Trigger enableTrigger(
-            @NonNull Target target,
             @NonNull String triggerID,
             boolean enable)
             throws IoTCloudException {
 
-        if (target == null) {
-            throw new IllegalArgumentException("target is null");
+        if (this.target == null) {
+            throw new IllegalStateException("Can not perform this action before onboarding");
         }
         if (TextUtils.isEmpty(triggerID)) {
             throw new IllegalArgumentException("triggerID is null or empty");
         }
-        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/triggers/{2}/{3}", this.appID, target.getID().toString(), triggerID, (enable ? "enable" : "disable"));
+        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/triggers/{2}/{3}", this.appID, this.target.getID().toString(), triggerID, (enable ? "enable" : "disable"));
         String url = Path.combine(this.baseUrl, path);
         Map<String, String> headers = this.newHeader();
         IoTRestRequest request = new IoTRestRequest(url, IoTRestRequest.Method.PUT, headers);
         this.restClient.sendRequest(request);
-        return this.getTrigger(target, triggerID);
+        return this.getTrigger(triggerID);
     }
 
     /**
      * Delete the specified Trigger.
-     * @param target Target of which the Trigger stored.
      * @param triggerID ID of the Trigger to be deleted.
      * @return Deleted Trigger Instance.
      * @throws IoTCloudException Thrown when failed to connect IoT Cloud Server.
@@ -597,18 +580,17 @@ public class IoTCloudAPI implements Parcelable, Serializable {
     @NonNull
     @WorkerThread
     public Trigger deleteTrigger(
-            @NonNull Target target,
             @NonNull String triggerID) throws
             IoTCloudException {
 
-        if (target == null) {
-            throw new IllegalArgumentException("target is null");
+        if (this.target == null) {
+            throw new IllegalStateException("Can not perform this action before onboarding");
         }
         if (TextUtils.isEmpty(triggerID)) {
             throw new IllegalArgumentException("triggerID is null or empty");
         }
 
-        Trigger trigger = this.getTrigger(target, triggerID);
+        Trigger trigger = this.getTrigger(triggerID);
         String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/triggers/{2}", this.appID, target.getID().toString(), triggerID);
         String url = Path.combine(this.baseUrl, path);
         Map<String, String> headers = this.newHeader();
@@ -619,7 +601,6 @@ public class IoTCloudAPI implements Parcelable, Serializable {
 
     /**
      * List Triggers belongs to the specified Target.
-     * @param target Target of which the Trigger stored.
      * @param bestEffortLimit limit the maximum number of the Triggers in the
      *                        Response. It ensures numbers in
      *                        response is equals to or less than specified number.
@@ -640,15 +621,14 @@ public class IoTCloudAPI implements Parcelable, Serializable {
     @NonNull
     @WorkerThread
     public Pair<List<Trigger>, String> listTriggers(
-            @NonNull Target target,
             int bestEffortLimit,
             @Nullable String paginationKey) throws
             IoTCloudException {
-        if (target == null) {
-            throw new IllegalArgumentException("target is null");
+        if (this.target == null) {
+            throw new IllegalStateException("Can not perform this action before onboarding");
         }
 
-        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/triggers", this.appID, target.getID().toString());
+        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/triggers", this.appID, this.target.getID().toString());
         String url = Path.combine(this.baseUrl, path);
         Map<String, String> headers = this.newHeader();
         IoTRestRequest request = new IoTRestRequest(url, IoTRestRequest.Method.GET, headers);
@@ -691,17 +671,16 @@ public class IoTCloudAPI implements Parcelable, Serializable {
     @NonNull
     @WorkerThread
     public <S extends TargetState> S getTargetState(
-            @NonNull Target target,
             @NonNull Class<S> classOfS) throws IoTCloudException {
 
-        if (target == null) {
-            throw new IllegalArgumentException("target is null");
+        if (this.target == null) {
+            throw new IllegalStateException("Can not perform this action before onboarding");
         }
         if (classOfS == null) {
             throw new IllegalArgumentException("classOfS is null");
         }
 
-        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/states", this.appID, target.getID().toString());
+        String path = MessageFormat.format("/iot-api/apps/{0}/targets/{1}/states", this.appID, this.target.getID().toString());
         String url = Path.combine(this.baseUrl, path);
         Map<String, String> headers = this.newHeader();
         IoTRestRequest request = new IoTRestRequest(url, IoTRestRequest.Method.GET, headers);
@@ -744,6 +723,13 @@ public class IoTCloudAPI implements Parcelable, Serializable {
      */
     public Owner getOwner() {
         return this.owner;
+    }
+
+    public Target getTarget() {
+        return this.target;
+    }
+    public void setTarget() {
+        this.target = target;
     }
 
     private Schema getSchema(String schemaName, int schemaVersion) {
@@ -806,12 +792,12 @@ public class IoTCloudAPI implements Parcelable, Serializable {
         this.appKey = in.readString();
         this.baseUrl = in.readString();
         this.owner = in.readParcelable(Owner.class.getClassLoader());
+        this.target = in.readParcelable(Target.class.getClassLoader());
         ArrayList<Schema> schemas = in.createTypedArrayList(Schema.CREATOR);
         for (Schema schema : schemas) {
             this.schemas.put(new Pair<String, Integer>(schema.getSchemaName(), schema.getSchemaVersion()), schema);
         }
         this.restClient = new IoTRestClient();
-        this.onBoarded = (in.readByte() != 0);
         this.installationID = in.readString();
     }
     public static final Creator<IoTCloudAPI> CREATOR = new Creator<IoTCloudAPI>() {
@@ -835,8 +821,8 @@ public class IoTCloudAPI implements Parcelable, Serializable {
         dest.writeString(this.appKey);
         dest.writeString(this.baseUrl);
         dest.writeParcelable(this.owner, flags);
+        dest.writeParcelable(this.target, flags);
         dest.writeTypedList(new ArrayList<Schema>(this.schemas.values()));
-        dest.writeByte((byte) ((Boolean) this.onBoarded ? 1 : 0));
         dest.writeString(this.installationID);
     }
 

--- a/iotcloudsdktest/src/main/java/com/kii/iotcloud/CommandTest.java
+++ b/iotcloudsdktest/src/main/java/com/kii/iotcloud/CommandTest.java
@@ -39,7 +39,7 @@ public class CommandTest extends LargeTestCaseBase {
         SetColorTemperature setColorTemperature = new SetColorTemperature(25);
         actions1.add(setColor);
         actions1.add(setColorTemperature);
-        Command command1 = api.postNewCommand(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions1);
+        Command command1 = api.postNewCommand(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions1);
         Assert.assertNotNull(command1.getCommandID());
         Assert.assertEquals(DEMO_SCHEMA_NAME, command1.getSchemaName());
         Assert.assertEquals(DEMO_SCHEMA_VERSION, command1.getSchemaVersion());
@@ -61,7 +61,7 @@ public class CommandTest extends LargeTestCaseBase {
         TurnPower turnPower = new TurnPower(true);
         actions2.add(setBrightness);
         actions2.add(turnPower);
-        Command command2 = api.postNewCommand(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions2);
+        Command command2 = api.postNewCommand(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions2);
         Assert.assertNotNull(command2.getCommandID());
         Assert.assertEquals(DEMO_SCHEMA_NAME, command2.getSchemaName());
         Assert.assertEquals(DEMO_SCHEMA_VERSION, command2.getSchemaVersion());
@@ -78,7 +78,7 @@ public class CommandTest extends LargeTestCaseBase {
         Assert.assertEquals(turnPower.power, ((TurnPower)command2.getActions().get(1)).power);
         Assert.assertNull(command2.getActionResults());
         // list commands
-        Pair<List<Command>, String> results = api.listCommands(target, 100, null);
+        Pair<List<Command>, String> results = api.listCommands(100, null);
         Assert.assertNull(results.second);
         List<Command> commands = results.first;
         Assert.assertEquals(2, commands.size());
@@ -124,7 +124,7 @@ public class CommandTest extends LargeTestCaseBase {
         Assert.assertEquals(TypedID.Types.THING, target.getID().getType());
         Assert.assertNotNull(target.getAccessToken());
 
-        Pair<List<Command>, String> results = api.listCommands(target, 10, null);
+        Pair<List<Command>, String> results = api.listCommands(10, null);
         Assert.assertNull(results.second);
         List<Command> commands = results.first;
         Assert.assertEquals(0, commands.size());

--- a/iotcloudsdktest/src/main/java/com/kii/iotcloud/TriggerTest.java
+++ b/iotcloudsdktest/src/main/java/com/kii/iotcloud/TriggerTest.java
@@ -49,7 +49,7 @@ public class TriggerTest extends LargeTestCaseBase {
         Condition condition1 = new Condition(new Equals("power", true));
         StatePredicate predicate1 = new StatePredicate(condition1, TriggersWhen.CONDITION_TRUE);
 
-        Trigger trigger1 = api.postNewTrigger(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions1, predicate1);
+        Trigger trigger1 = api.postNewTrigger(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions1, predicate1);
         Assert.assertNotNull(trigger1.getTriggerID());
         Assert.assertFalse(trigger1.disabled());
         Assert.assertNull(trigger1.getDisabledReason());
@@ -79,13 +79,13 @@ public class TriggerTest extends LargeTestCaseBase {
         Assert.assertEquals(Boolean.TRUE, ((Equals)trigger1Predicate.getCondition().getClause()).getValue());
 
         // disable/enable trigger
-        trigger1 = api.enableTrigger(target, trigger1.getTriggerID(), false);
+        trigger1 = api.enableTrigger(trigger1.getTriggerID(), false);
         Assert.assertTrue(trigger1.disabled());
-        trigger1 = api.enableTrigger(target, trigger1.getTriggerID(), true);
+        trigger1 = api.enableTrigger(trigger1.getTriggerID(), true);
         Assert.assertFalse(trigger1.disabled());
 
         // get target state (empty)
-        LightState lightState = api.getTargetState(target, LightState.class);
+        LightState lightState = api.getTargetState(LightState.class);
 
         // create new trigger
         List<Action> actions2 = new ArrayList<Action>();
@@ -96,7 +96,7 @@ public class TriggerTest extends LargeTestCaseBase {
         Condition condition2 = new Condition(new Equals("power", false));
         StatePredicate predicate2 = new StatePredicate(condition2, TriggersWhen.CONDITION_CHANGED);
 
-        Trigger trigger2 = api.postNewTrigger(target, DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions2, predicate2);
+        Trigger trigger2 = api.postNewTrigger(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions2, predicate2);
         Assert.assertNotNull(trigger2.getTriggerID());
         Assert.assertFalse(trigger2.disabled());
         Assert.assertNull(trigger2.getDisabledReason());
@@ -126,7 +126,7 @@ public class TriggerTest extends LargeTestCaseBase {
         Assert.assertEquals(Boolean.FALSE, ((Equals)trigger2Predicate.getCondition().getClause()).getValue());
 
         // list triggers
-        Pair<List<Trigger>, String> results = api.listTriggers(target, 100, null);
+        Pair<List<Trigger>, String> results = api.listTriggers(100, null);
         Assert.assertNull(results.second);
         List<Trigger> triggers = results.first;
         Assert.assertEquals(2, triggers.size());
@@ -198,7 +198,7 @@ public class TriggerTest extends LargeTestCaseBase {
         Assert.assertEquals(Boolean.FALSE, ((Equals)trigger2Predicate.getCondition().getClause()).getValue());
 
         // delete triiger
-        api.deleteTrigger(target, trigger1.getTriggerID());
+        api.deleteTrigger(trigger1.getTriggerID());
 
         // update trigger
         List<Action> actions3 = new ArrayList<Action>();
@@ -208,10 +208,10 @@ public class TriggerTest extends LargeTestCaseBase {
         actions3.add(turnPower3);
         Condition condition3 = new Condition(Range.greaterThan("brightness", 100));
         StatePredicate predicate3 = new StatePredicate(condition3, TriggersWhen.CONDITION_FALSE_TO_TRUE);
-        api.patchTrigger(target, trigger2.getTriggerID(), DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions3, predicate3);
+        api.patchTrigger(trigger2.getTriggerID(), DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions3, predicate3);
 
         // list triggers
-        results = api.listTriggers(target, 100, null);
+        results = api.listTriggers(100, null);
         Assert.assertNull(results.second);
         triggers = results.first;
         Assert.assertEquals(1, triggers.size());
@@ -257,7 +257,7 @@ public class TriggerTest extends LargeTestCaseBase {
         Assert.assertEquals(TypedID.Types.THING, target.getID().getType());
         Assert.assertNotNull(target.getAccessToken());
 
-        Pair<List<Trigger>, String> results = api.listTriggers(target, 100, null);
+        Pair<List<Trigger>, String> results = api.listTriggers(100, null);
         Assert.assertNull(results.second);
         List<Trigger> triggers = results.first;
         Assert.assertEquals(0, triggers.size());


### PR DESCRIPTION
@satoshikumano 

まだTESTを修正していないのでコンパイルが通らない状態ですが、TargetのインスタンスをIoTCloudAPIに持たせるのはどうでしょうか？
現状のIoTCloudAPI#onBoarded()はあまり意味のないメソッドで、結局重要なのはTargetのインスタンスがあるかどうかです。
基本的にTargetのインスタンスが無いと再度、onBoardしないと何もできませんし、IoTCloudAPIがTargetを持っていれば、IoTCloudAPIがParcelableであるメリットを最大限生かせます。
ただ全体的にメソッドのインターフェースが変わるので影響範囲は大きいです。逆に今ならまだ修正できるタイミングとも言えます。
